### PR TITLE
Use single hook to store `ScopeEmitter` in `useCreateScope`

### DIFF
--- a/.changeset/cruel-lizards-wink.md
+++ b/.changeset/cruel-lizards-wink.md
@@ -1,0 +1,5 @@
+---
+"react-impulse": patch
+---
+
+Utilize a single hook to store `ScopeEmitter` in internal `useCreateScope` hook.

--- a/packages/react-impulse/src/derived-impulse.ts
+++ b/packages/react-impulse/src/derived-impulse.ts
@@ -7,7 +7,7 @@ import { ScopeEmitter } from "./scope-emitter"
 export class DerivedImpulse<T> extends BaseImpulse<T> {
   // the inner scope proxies the setters to the outer scope
   private readonly _scope = {
-    [EMITTER_KEY]: ScopeEmitter._init(() => {
+    [EMITTER_KEY]: new ScopeEmitter(() => {
       if (
         this._compare(this._value, this._getValue(STATIC_SCOPE), STATIC_SCOPE)
       ) {

--- a/packages/react-impulse/src/scope-emitter.ts
+++ b/packages/react-impulse/src/scope-emitter.ts
@@ -52,16 +52,6 @@ export class ScopeEmitterQueue {
 export class ScopeEmitter {
   private static _queue: null | ScopeEmitterQueue = null
 
-  /**
-   * Initializes and returns a new instance of the `ScopeEmitter` class.
-   *
-   * @param emit - A callback function to be invoked when the scope emits.
-   * @param skipBatching - opt-out from emit batching. Necessary for derived impulses.
-   */
-  public static _init(emit: VoidFunction, skipBatching = false): ScopeEmitter {
-    return new ScopeEmitter(emit, skipBatching)
-  }
-
   public static _schedule<TResult>(
     execute: (queue: ScopeEmitterQueue) => TResult,
   ): TResult {
@@ -92,9 +82,15 @@ export class ScopeEmitter {
 
   private _version = 0
 
-  private constructor(
+  /**
+   * Initializes and returns a new instance of the `ScopeEmitter` class.
+   *
+   * @param emit - A callback function to be invoked when the scope emits.
+   * @param skipBatching - opt-out from emit batching. Necessary for derived impulses.
+   */
+  public constructor(
     public readonly _emit: VoidFunction,
-    public readonly _skipBatching: boolean,
+    public readonly _skipBatching = false,
   ) {}
 
   public _detachFromAll(): void {

--- a/packages/react-impulse/src/subscribe.ts
+++ b/packages/react-impulse/src/subscribe.ts
@@ -25,7 +25,7 @@ export function subscribe(
     })
   }
 
-  const emitter = ScopeEmitter._init(emit)
+  const emitter = new ScopeEmitter(emit)
 
   emit()
 


### PR DESCRIPTION
Utilize a single hook to store `ScopeEmitter` in internal `useCreateScope` hook.