### PR TITLE
 Fix CI release pipeline (mise lock drift + publish-branch guard)

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -6,6 +6,12 @@ runs:
   steps:
     - name: Setup mise
       uses: jdx/mise-action@v2
+      with:
+        # Pin to the local mise version so the lockfile header URL doesn't
+        # drift between local and CI installs (newer mise rewrites
+        # `mise.jdx.dev` -> `mise.en.dev`), which would otherwise leave the
+        # working tree dirty and trip pnpm publish's git-checks guard.
+        version: 2026.3.7
 
     # mise only shims a tool's primary bins (node, npm), so npx/corepack hit a
     # dud fallback shim. Put node's bin dir on PATH so third-party actions

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -7,10 +7,7 @@ runs:
     - name: Setup mise
       uses: jdx/mise-action@v2
       with:
-        # Pin to the local mise version so the lockfile header URL doesn't
-        # drift between local and CI installs (newer mise rewrites
-        # `mise.jdx.dev` -> `mise.en.dev`), which would otherwise leave the
-        # working tree dirty and trip pnpm publish's git-checks guard.
+        # Pin to local mise version to keep mise.lock stable across environments.
         version: 2026.3.7
 
     # mise only shims a tool's primary bins (node, npm), so npx/corepack hit a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
         uses: changesets/action@v1
         with:
           version: pnpm run version
-          publish: pnpm run release -- --tag=${{ github.ref_name == 'master' && 'latest' || github.ref_name == 'next' && 'next' || github.ref_name == 'alpha' && 'alpha' || github.ref_name == 'beta' && 'beta' || ' ' }}
+          publish: pnpm --recursive publish --access=public --publish-branch=${{ github.ref_name }} --tag=${{ github.ref_name == 'master' && 'latest' || github.ref_name == 'next' && 'next' || github.ref_name == 'alpha' && 'alpha' || github.ref_name == 'beta' && 'beta' || github.ref_name == 'snapshot' && 'snapshot' || 'latest' }} && pnpm exec changeset tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "preinstall": "npx -y only-allow pnpm",
     "cs": "changeset",
     "version": "changeset version",
-    "release": "pnpm --recursive publish --access=public && changeset tag",
     "size": "size-limit",
     "test": "vitest",
     "test:run": "pnpm test --run --reporter=dot",


### PR DESCRIPTION
## Summary

Two distinct CI release-pipeline bugs surfaced after pushing to master and then trying to repeat the publish from `snapshot`. Each is fixed in its own commit so they can be reverted independently if needed.

### 1. `Pin CI mise to 2026.3.7 to match local`

Newer mise (>= 2026.6.0) rewrites the doc-URL comment in `mise.lock`'s header from `mise.jdx.dev` to `mise.en.dev` on every install. With CI running newer mise than local, that single-line drift left the working tree dirty after `mise install`, and `pnpm publish`'s `git-checks` guard then aborted the release with `ERR_PNPM_GIT_UNCLEAN`.

Pin the action to the same mise version local uses so the lockfile is stable across environments. Bump both sides together when updating mise.

### 2. `Fix release publish for non-master branches`

Two issues fixed together in the publish step:

- **Publish hung on any non-master branch.** pnpm publish's default `publish-branch` guard is `master|main` and prompts interactively when the current branch doesn't match. With no TTY in CI, the job sat for 30+ minutes. Fix: pass `--publish-branch=${{ github.ref_name }}` so the guard always matches the current branch (and snapshot/next/alpha/beta become unblocked too).

- **`--tag` was going to the wrong command.** `pnpm run release -- --tag=X` appended `--tag` to the end of the script string `pnpm publish && changeset tag`, so it landed on `changeset tag` (which ignores it) instead of `pnpm publish`. Everything was being published to npm under `latest` regardless of branch — the existing branch-to-tag ternary was effectively dead code. Inline the publish command in the workflow so flags reach `pnpm publish` directly.

Side effect: the `release` script in `package.json` is now unused (CI is the only intended publisher), so removed it. Snapshot branch added to the dist-tag mapping.
 