### PR TITLE
Fix FormSwitch verbose output for nested   composite branches

### DIFF
--- a/.changeset/quiet-switches-recurse.md
+++ b/.changeset/quiet-switches-recurse.md
@@ -1,0 +1,5 @@
+---
+"@owanturist/signal-form": patch
+---
+
+Fix `FormSwitch` verbose output collapsing nested composite branches to their concise shape. `FormSwitchState._outputVerbose` was reading each branch's concise `_output` instead of `_outputVerbose`, so any branch that was itself a `FormSwitch`/`FormShape`/`FormList`/`FormOptional` rendered concisely when reached from a parent switch — even though reading the same node directly produced the verbose shape. Closes [#1071](https://github.com/owanturist/signal/issues/1071).

--- a/packages/signal-form/src/form-switch/_internal/form-switch-state.ts
+++ b/packages/signal-form/src/form-switch/_internal/form-switch-state.ts
@@ -441,7 +441,7 @@ class FormSwitchState<
 
   public readonly _outputVerbose = Signal(
     (monitor): FormSwitchOutputVerbose<TKind, TBranches> =>
-      this._toVerbose(monitor, ({ _output }) => _output),
+      this._toVerbose(monitor, ({ _outputVerbose }) => _outputVerbose),
   )
 
   // V A L I D

--- a/packages/signal-form/tests/form-switch/output.spec.ts
+++ b/packages/signal-form/tests/form-switch/output.spec.ts
@@ -102,6 +102,68 @@ describe("types", () => {
   })
 })
 
+describe("nested verbose output", () => {
+  it("returns verbose shape for a switch nested directly in a switch branch", ({ monitor }) => {
+    const inner = FormSwitch(FormUnit<"_a" | "_b">("_a"), {
+      _a: FormUnit(1),
+      _b: FormUnit("two"),
+    })
+
+    const parent = FormSwitch(FormUnit<"_x" | "_y">("_x"), {
+      _x: inner,
+      _y: FormUnit("zzz"),
+    })
+
+    expect(parent.getOutput(monitor, params._second)).toStrictEqual({
+      active: "_x",
+      branches: {
+        _x: {
+          active: "_a",
+          branches: {
+            _a: 1,
+            _b: "two",
+          },
+        },
+        _y: "zzz",
+      },
+    })
+  })
+
+  it("returns verbose shape for a switch nested inside a shape inside a switch branch", ({
+    monitor,
+  }) => {
+    const innerSwitch = FormSwitch(FormUnit<"_a" | "_b">("_b"), {
+      _a: FormUnit(1),
+      _b: FormShape({
+        nested: FormUnit("inside"),
+      }),
+    })
+
+    const parent = FormSwitch(FormUnit<"_metrics" | "_markdown">("_metrics"), {
+      _metrics: FormShape({
+        settings: innerSwitch,
+      }),
+      _markdown: FormUnit(""),
+    })
+
+    expect(parent.getOutput(monitor, params._second)).toStrictEqual({
+      active: "_metrics",
+      branches: {
+        _metrics: {
+          settings: {
+            active: "_b",
+            branches: {
+              _a: 1,
+              _b: { nested: "inside" },
+            },
+          },
+        },
+        _markdown: "",
+      },
+    })
+  })
+})
+
 describe("when branch is initially invalid", () => {
   it("returns null for initially invalid active", ({ monitor }) => {
     const form = FormSwitch(


### PR DESCRIPTION
Fix `FormSwitch` verbose output collapsing nested composite branches to their concise shape. `FormSwitchState._outputVerbose` was reading each branch's concise `_output` instead of `_outputVerbose`, so any branch that was itself a `FormSwitch`/`FormShape`/`FormList`/`FormOptional` rendered concisely when reached from a parent switch — even though reading the same node directly produced the verbose shape. Closes [#1071](https://github.com/owanturist/signal/issues/1071).
