### PR TITLE
Bugfix 912 Single output function

### DIFF
--- a/.changeset/strict-units-reject.md
+++ b/.changeset/strict-units-reject.md
@@ -1,0 +1,5 @@
+---
+"@owanturist/signal-form": patch
+---
+
+Fix `FormUnit` accepting multiple output functions at the type level. Previously TypeScript silently allowed combinations like `{ transform, validate }`, `{ transform, schema }`, or `{ validate, schema }`, but at runtime only one was applied (priority: `schema` > `validate` > `transform`) — the others were silently ignored. `FormUnitTransformedOptions`, `FormUnitValidatedOptions`, and `FormUnitSchemaOptions` are now mutually exclusive: passing more than one of `transform`/`validate`/`schema` is a compile error. `validateOn` is also rejected on transform-only options, since the transform branch has no validation lifecycle. Runtime behavior is unchanged. Closes [#912](https://github.com/owanturist/signal/issues/912).

--- a/packages/signal-form/src/form-unit/form-unit.ts
+++ b/packages/signal-form/src/form-unit/form-unit.ts
@@ -105,8 +105,12 @@ interface FormUnitOptions<TInput, TError = null> {
 }
 
 interface FormUnitTransformedOptions<TInput, TError = null, TOutput = TInput>
-  extends Omit<FormUnitOptions<TInput, TError>, "isOutputEqual"> {
+  extends FormUnitOptions<TInput, TError> {
   readonly transform: FormUnitTransformer<TInput, TOutput>
+
+  readonly validate?: never
+  readonly schema?: never
+  readonly validateOn?: never
 
   /**
    * PERFORMANCE OPTIMIZATION
@@ -123,26 +127,55 @@ interface FormUnitTransformedOptions<TInput, TError = null, TOutput = TInput>
 }
 
 interface FormUnitSchemaOptions<TInput, TOutput = TInput>
-  extends Omit<
-    FormUnitTransformedOptions<TInput, ReadonlyArray<string>, TOutput>,
-    "transform" | "isErrorEqual"
-  > {
+  extends Omit<FormUnitOptions<TInput, ReadonlyArray<string>>, "isErrorEqual"> {
+  readonly schema: ZodLikeSchema<TOutput>
+
   /**
    * @default "onTouch"
    */
   readonly validateOn?: ValidateStrategy
 
-  readonly schema: ZodLikeSchema<TOutput>
+  readonly transform?: never
+  readonly validate?: never
+
+  /**
+   * PERFORMANCE OPTIMIZATION
+   *
+   * A equality check function that determines whether the output value changes.
+   * When it does, the {@link SignalForm.getOutput} returns the new value.
+   *
+   * Useful for none primitive values such as Objects, Arrays, Date, etc.
+   * Intended to improve performance but do not affect business logic.
+   *
+   * @default Object.is
+   */
+  readonly isOutputEqual?: Equal<TOutput>
 }
 
 interface FormUnitValidatedOptions<TInput, TError = null, TOutput = TInput>
-  extends Omit<FormUnitTransformedOptions<TInput, TError, TOutput>, "transform"> {
+  extends FormUnitOptions<TInput, TError> {
+  readonly validate: FormUnitValidator<TInput, TError, TOutput>
+
   /**
    * @default "onTouch"
    */
   readonly validateOn?: ValidateStrategy
 
-  readonly validate: FormUnitValidator<TInput, TError, TOutput>
+  readonly transform?: never
+  readonly schema?: never
+
+  /**
+   * PERFORMANCE OPTIMIZATION
+   *
+   * A equality check function that determines whether the output value changes.
+   * When it does, the {@link SignalForm.getOutput} returns the new value.
+   *
+   * Useful for none primitive values such as Objects, Arrays, Date, etc.
+   * Intended to improve performance but do not affect business logic.
+   *
+   * @default Object.is
+   */
+  readonly isOutputEqual?: Equal<TOutput>
 }
 
 function FormUnit<TInput, TError = null, TOutput = TInput>(

--- a/packages/signal-form/tests/form-unit/form-unit.spec.ts
+++ b/packages/signal-form/tests/form-unit/form-unit.spec.ts
@@ -297,6 +297,64 @@ describe("FormUnitValidatedOptions", () => {
   })
 })
 
+/**
+ * bugfix: Do not allow multiple FormUnit output functions #912
+ * @link https://github.com/owanturist/signal/issues/912
+ */
+describe("does not allow multiple output functions", () => {
+  it("rejects transform together with validate", ({ monitor }) => {
+    const value = FormUnit("", {
+      // @ts-expect-error transform and validate are mutually exclusive
+      transform: (input: string) => input.trim(),
+      validate: (input: string) => (input.length > 0 ? [null, input] : ["too short", null]),
+    })
+
+    expect(value.getInput(monitor)).toBe("")
+  })
+
+  it("rejects transform together with schema", ({ monitor }) => {
+    const value = FormUnit("", {
+      // @ts-expect-error transform and schema are mutually exclusive
+      transform: (input: string) => input.trim(),
+      schema: z.string().min(1),
+    })
+
+    expect(value.getInput(monitor)).toBe("")
+  })
+
+  it("rejects validate together with schema", ({ monitor }) => {
+    const value = FormUnit("", {
+      // @ts-expect-error validate and schema are mutually exclusive
+      validate: (input: string): Result<string, string> =>
+        input.length > 0 ? [null, input] : ["too short", null],
+      schema: z.string().min(1),
+    })
+
+    expect(value.getInput(monitor)).toBe("")
+  })
+
+  it("rejects transform, validate and schema all together", ({ monitor }) => {
+    const value = FormUnit("", {
+      // @ts-expect-error transform, validate and schema are mutually exclusive
+      transform: (input: string) => input.trim(),
+      validate: (input: string) => (input.length > 0 ? [null, input] : ["too short", null]),
+      schema: z.string().min(1),
+    })
+
+    expect(value.getInput(monitor)).toBe("")
+  })
+
+  it("rejects validateOn with transform", ({ monitor }) => {
+    const value = FormUnit("", {
+      // @ts-expect-error validateOn has no meaning without validate or schema
+      transform: (input: string) => input.trim(),
+      validateOn: "onInit",
+    })
+
+    expect(value.getInput(monitor)).toBe("")
+  })
+})
+
 describe("FormUnitSchemaOptions", () => {
   it("defines unit with schema as validator", ({ monitor }) => {
     const value = FormUnit(0, {

--- a/packages/signal-form/tests/form-unit/get-output.spec.ts
+++ b/packages/signal-form/tests/form-unit/get-output.spec.ts
@@ -6,6 +6,7 @@ import { params } from "~/tools/params"
 import {
   FormUnit,
   type FormUnitSchemaOptions,
+  type FormUnitTransformedOptions,
   type FormUnitValidatedOptions,
   type Result,
   type ZodLikeSafeParseResult,
@@ -149,7 +150,7 @@ describe("when initial error is defined", () => {
 describe("when transform is defined", () => {
   function setup(
     initial = "",
-    options?: Partial<FormUnitValidatedOptions<string, number, number>>,
+    options?: Partial<FormUnitTransformedOptions<string, number, number>>,
   ) {
     return FormUnit(initial, {
       transform: (input) => input.length,
@@ -165,15 +166,15 @@ describe("when transform is defined", () => {
     expect(output).toBe(3)
   })
 
-  it("returns output after validation", ({ monitor }) => {
-    const value = setup("123", { validateOn: "onInit" })
+  it("returns output regardless of validation lifecycle", ({ monitor }) => {
+    const value = setup("123")
     const output = value.getOutput(monitor)
 
     expect(output).toBe(3)
   })
 
-  it("returns null before validation when error is specified", ({ monitor }) => {
-    const value = setup("1", { validateOn: "onInit", error: 2 })
+  it("returns null when error is specified", ({ monitor }) => {
+    const value = setup("1", { error: 2 })
 
     const output0 = value.getOutput(monitor)
     expect(output0).toBeNull()
@@ -183,8 +184,8 @@ describe("when transform is defined", () => {
     expect(output1).toBe(1)
   })
 
-  it("returns null after validation when error is set", ({ monitor }) => {
-    const value = setup("1", { validateOn: "onInit" })
+  it("returns null after error is set", ({ monitor }) => {
+    const value = setup("1")
 
     const output0 = value.getOutput(monitor)
     expect(output0).toBe(1)


### PR DESCRIPTION
Fix `FormUnit` accepting multiple output functions at the type level. Previously TypeScript silently allowed combinations like `{ transform, validate }`, `{ transform, schema }`, or `{ validate, schema }`, but at runtime only one was applied (priority: `schema` > `validate` > `transform`) — the others were silently ignored. `FormUnitTransformedOptions`, `FormUnitValidatedOptions`, and `FormUnitSchemaOptions` are now mutually exclusive: passing more than one of `transform`/`validate`/`schema` is a compile error. `validateOn` is also rejected on transform-only options, since the transform branch has no validation lifecycle. Runtime behavior is unchanged. Closes [#912](https://github.com/owanturist/signal/issues/912).
