### PR TITLE
FormListInputSetter now nests per-element setters

### DIFF
--- a/.changeset/formlist-per-element-input-setters.md
+++ b/.changeset/formlist-per-element-input-setters.md
@@ -1,0 +1,35 @@
+---
+"@owanturist/signal-form": minor
+---
+
+`FormList.setInput` / `setInitial` / `reset` now accept per-element setters inside the array, and `FormListOptions.initial` / `input` are restricted to plain value arrays (no callback at the options level).
+
+## `setInput` / `setInitial` / `reset` accept per-element setters
+
+Each slot of the array argument may now be either a raw input value or a `Setter<TInput, [TInput, TInput]>` — the same setter shape an individual element's `setInput` accepts. The top-level callback form (a function that returns the full array) still works.
+
+```ts
+const list = FormList((n: number) => FormUnit(n), { initial: [0, 1, 2] })
+
+// Before: only raw values were allowed inside the array.
+list.setInput([10, 20, 30])
+
+// After: per-slot setters are allowed too.
+list.setInput([10, (prev) => prev + 1, 30])
+```
+
+## `FormListOptions.initial` / `input` no longer accept a callback
+
+The options-level `initial` and `input` are now typed as `FormListInput<TElement>` (a plain `ReadonlyArray<TInput>`), not `FormListInputSetter<TElement>`. There is no prior state to feed a callback at construction time, so the callback form is gone.
+
+```ts
+// Before: callback was accepted (and was always called with `[]`).
+FormList((n: number) => FormUnit(n), {
+  initial: (prev) => prev.concat([1, 2, 3]),
+})
+
+// After: pass the array directly.
+FormList((n: number) => FormUnit(n), {
+  initial: [1, 2, 3],
+})
+```

--- a/packages/signal-form/src/form-list/form-list-input-setter.ts
+++ b/packages/signal-form/src/form-list/form-list-input-setter.ts
@@ -1,12 +1,12 @@
 import type { Setter } from "~/tools/setter"
 
-import type { GetFormInput } from "../signal-form/get-form-input"
+import type { GetFormInputSetter } from "../signal-form/get-form-input-setter"
 import type { SignalForm } from "../signal-form/signal-form"
 
 import type { FormListInput } from "./form-list-input"
 
 type FormListInputSetter<TElement extends SignalForm> = Setter<
-  ReadonlyArray<GetFormInput<TElement>>,
+  ReadonlyArray<GetFormInputSetter<TElement>>,
   [FormListInput<TElement>, FormListInput<TElement>]
 >
 

--- a/packages/signal-form/src/form-list/form-list.ts
+++ b/packages/signal-form/src/form-list/form-list.ts
@@ -8,7 +8,7 @@ import type { SignalForm } from "../signal-form/signal-form"
 
 import type { FormListErrorSetter } from "./form-list-error-setter"
 import type { FormListFlagSetter } from "./form-list-flag-setter"
-import type { FormListInputSetter } from "./form-list-input-setter"
+import type { FormListInput } from "./form-list-input"
 import type { FormListValidateOnSetter } from "./form-list-validate-on-setter"
 import { FormList as FormListImpl } from "./_internal/form-list"
 import { FormListState } from "./_internal/form-list-state"
@@ -24,12 +24,12 @@ interface FormListOptions<TElement extends SignalForm> {
   /**
    * @default []
    */
-  readonly initial?: FormListInputSetter<TElement>
+  readonly initial?: FormListInput<TElement>
 
   /**
    * @default {@link initial}
    */
-  readonly input?: FormListInputSetter<TElement>
+  readonly input?: FormListInput<TElement>
 
   readonly touched?: FormListFlagSetter<TElement>
   readonly validateOn?: FormListValidateOnSetter<TElement>

--- a/packages/signal-form/tests/form-list/reset.spec.ts
+++ b/packages/signal-form/tests/form-list/reset.spec.ts
@@ -20,7 +20,10 @@ it("matches the type definition", ({ monitor }) => {
 
   expectTypeOf(form.reset).toEqualTypeOf<
     (
-      resetter?: Setter<ReadonlyArray<number>, [ReadonlyArray<number>, ReadonlyArray<number>]>,
+      resetter?: Setter<
+        ReadonlyArray<Setter<number, [number, number]>>,
+        [ReadonlyArray<number>, ReadonlyArray<number>]
+      >,
     ) => void
   >()
 

--- a/packages/signal-form/tests/form-list/set-initial.spec.ts
+++ b/packages/signal-form/tests/form-list/set-initial.spec.ts
@@ -23,7 +23,12 @@ it("matches the type definition", ({ monitor }) => {
   })
 
   expectTypeOf(form.setInitial).toEqualTypeOf<
-    (setter: Setter<ReadonlyArray<number>, [ReadonlyArray<number>, ReadonlyArray<number>]>) => void
+    (
+      setter: Setter<
+        ReadonlyArray<Setter<number, [number, number]>>,
+        [ReadonlyArray<number>, ReadonlyArray<number>]
+      >,
+    ) => void
   >()
 
   expectTypeOf(form.getElements(monitor).at(0)!.setInitial).toEqualTypeOf<
@@ -43,14 +48,24 @@ it("matches the nested type definition", ({ monitor }) => {
   expectTypeOf(form.setInitial).toEqualTypeOf<
     (
       setter: Setter<
-        ReadonlyArray<ReadonlyArray<number>>,
+        ReadonlyArray<
+          Setter<
+            ReadonlyArray<Setter<number, [number, number]>>,
+            [ReadonlyArray<number>, ReadonlyArray<number>]
+          >
+        >,
         [ReadonlyArray<ReadonlyArray<number>>, ReadonlyArray<ReadonlyArray<number>>]
       >,
     ) => void
   >()
 
   expectTypeOf(form.getElements(monitor).at(0)!.setInitial).toEqualTypeOf<
-    (setter: Setter<ReadonlyArray<number>, [ReadonlyArray<number>, ReadonlyArray<number>]>) => void
+    (
+      setter: Setter<
+        ReadonlyArray<Setter<number, [number, number]>>,
+        [ReadonlyArray<number>, ReadonlyArray<number>]
+      >,
+    ) => void
   >()
 
   expectTypeOf(
@@ -169,6 +184,24 @@ it("updates list's initial value from an element's setInitial", ({ monitor }) =>
     { first: 1, second: "1" },
     { first: 3, second: "3" },
   ])
+})
+
+it("passes an element in the transform function", ({ monitor }) => {
+  const form = FormList((input: number) => FormUnit(input), {
+    initial: [0, 1, 2],
+  })
+
+  form.setInitial([10, (x) => x + 3])
+  expect(form.getInitial(monitor)).toStrictEqual([10, 4])
+})
+
+it("passes an element in the list transform function", ({ monitor }) => {
+  const form = FormList((input: number) => FormUnit(input), {
+    initial: [0, 1, 2],
+  })
+
+  form.setInitial((elements) => elements.map(() => (x) => x + 1))
+  expect(form.getInitial(monitor)).toStrictEqual([1, 2, 3])
 })
 
 describe("adding a new element to the list's beginning", () => {

--- a/packages/signal-form/tests/form-list/set-input.spec.ts
+++ b/packages/signal-form/tests/form-list/set-input.spec.ts
@@ -8,7 +8,12 @@ it("matches the type definition", ({ monitor }) => {
   })
 
   expectTypeOf(form.setInput).toEqualTypeOf<
-    (setter: Setter<ReadonlyArray<number>, [ReadonlyArray<number>, ReadonlyArray<number>]>) => void
+    (
+      setter: Setter<
+        ReadonlyArray<Setter<number, [number, number]>>,
+        [ReadonlyArray<number>, ReadonlyArray<number>]
+      >,
+    ) => void
   >()
 
   expectTypeOf(form.getElements(monitor).at(0)!.setInput).toEqualTypeOf<
@@ -59,6 +64,24 @@ it("passes the list in the transform function", ({ monitor }) => {
   })
 
   form.setInput((elements) => elements.map((x) => x + 1))
+  expect(form.getInput(monitor)).toStrictEqual([1, 2, 3])
+})
+
+it("passes an element in the transform function", ({ monitor }) => {
+  const form = FormList((input: number) => FormUnit(input), {
+    initial: [0, 1, 2],
+  })
+
+  form.setInput([10, (x) => x + 3])
+  expect(form.getInput(monitor)).toStrictEqual([10, 4])
+})
+
+it("passes an element in the list transform function", ({ monitor }) => {
+  const form = FormList((input: number) => FormUnit(input), {
+    initial: [0, 1, 2],
+  })
+
+  form.setInput((elements) => elements.map(() => (x) => x + 1))
   expect(form.getInput(monitor)).toStrictEqual([1, 2, 3])
 })
 


### PR DESCRIPTION

`FormList.setInput` / `setInitial` / `reset` now accept per-element setters inside the array, and `FormListOptions.initial` / `input` are restricted to plain value arrays (no callback at the options level).

## `setInput` / `setInitial` / `reset` accept per-element setters

Each slot of the array argument may now be either a raw input value or a `Setter<TInput, [TInput, TInput]>` — the same setter shape an individual element's `setInput` accepts. The top-level callback form (a function that returns the full array) still works.

```ts
const list = FormList((n: number) => FormUnit(n), { initial: [0, 1, 2] })

// Before: only raw values were allowed inside the array.
list.setInput([10, 20, 30])

// After: per-slot setters are allowed too.
list.setInput([10, (prev) => prev + 1, 30])
```

## `FormListOptions.initial` / `input` no longer accept a callback

The options-level `initial` and `input` are now typed as `FormListInput<TElement>` (a plain `ReadonlyArray<TInput>`), not `FormListInputSetter<TElement>`. There is no prior state to feed a callback at construction time, so the callback form is gone.

```ts
// Before: callback was accepted (and was always called with `[]`).
FormList((n: number) => FormUnit(n), {
  initial: (prev) => prev.concat([1, 2, 3]),
})

// After: pass the array directly.
FormList((n: number) => FormUnit(n), {
  initial: [1, 2, 3],
})
```
