### PR TITLE
Revert per-element setter shape from `FormListInputSetter`

### DIFF
--- a/.changeset/revert-formlist-per-element-input-setters.md
+++ b/.changeset/revert-formlist-per-element-input-setters.md
@@ -1,0 +1,27 @@
+---
+"@owanturist/signal-form": minor
+---
+
+Revert per-element setter shape from `FormListInputSetter`. Each slot of `FormList.setInput` / `setInitial` / `reset` is now a plain input value again — the same shape as before the previous release. The top-level callback form (a function that returns the full array) is unchanged.
+
+The per-element setter form was unsound for the factory growth path: a partial setter (e.g. `{ first: 2 }` for a `FormShape` element) typechecked at the list level but produced a malformed slot when it reached the factory, which expects a full `GetFormInput<TElement>`. Without a way to type-distinguish "patch existing slot" from "grow new slot", the safer shape is plain inputs.
+
+```ts
+const list = FormList(
+  (input: { first: number; second: string }) =>
+    FormShape({ first: FormUnit(input.first), second: FormUnit(input.second) }),
+  { initial: [{ first: 1, second: "1" }] },
+)
+
+// Before: per-slot setter was accepted (and could be partial)
+list.setInitial([{ first: 2 }])
+
+// After: each slot must be a full input
+list.setInitial([{ first: 2, second: "2" }])
+```
+
+To update a single element without touching the rest, use the element's own setter:
+
+```ts
+list.getElements(monitor).at(0)!.setInitial({ first: 2, second: "2" })
+```

--- a/packages/signal-form/src/form-list/form-list-input-setter.ts
+++ b/packages/signal-form/src/form-list/form-list-input-setter.ts
@@ -1,12 +1,12 @@
 import type { Setter } from "~/tools/setter"
 
-import type { GetFormInputSetter } from "../signal-form/get-form-input-setter"
+import type { GetFormInput } from "../signal-form/get-form-input"
 import type { SignalForm } from "../signal-form/signal-form"
 
 import type { FormListInput } from "./form-list-input"
 
 type FormListInputSetter<TElement extends SignalForm> = Setter<
-  ReadonlyArray<GetFormInputSetter<TElement>>,
+  ReadonlyArray<GetFormInput<TElement>>,
   [FormListInput<TElement>, FormListInput<TElement>]
 >
 

--- a/packages/signal-form/tests/form-list/reset.spec.ts
+++ b/packages/signal-form/tests/form-list/reset.spec.ts
@@ -20,10 +20,7 @@ it("matches the type definition", ({ monitor }) => {
 
   expectTypeOf(form.reset).toEqualTypeOf<
     (
-      resetter?: Setter<
-        ReadonlyArray<Setter<number, [number, number]>>,
-        [ReadonlyArray<number>, ReadonlyArray<number>]
-      >,
+      resetter?: Setter<ReadonlyArray<number>, [ReadonlyArray<number>, ReadonlyArray<number>]>,
     ) => void
   >()
 

--- a/packages/signal-form/tests/form-list/set-initial.spec.ts
+++ b/packages/signal-form/tests/form-list/set-initial.spec.ts
@@ -23,12 +23,7 @@ it("matches the type definition", ({ monitor }) => {
   })
 
   expectTypeOf(form.setInitial).toEqualTypeOf<
-    (
-      setter: Setter<
-        ReadonlyArray<Setter<number, [number, number]>>,
-        [ReadonlyArray<number>, ReadonlyArray<number>]
-      >,
-    ) => void
+    (setter: Setter<ReadonlyArray<number>, [ReadonlyArray<number>, ReadonlyArray<number>]>) => void
   >()
 
   expectTypeOf(form.getElements(monitor).at(0)!.setInitial).toEqualTypeOf<
@@ -48,24 +43,14 @@ it("matches the nested type definition", ({ monitor }) => {
   expectTypeOf(form.setInitial).toEqualTypeOf<
     (
       setter: Setter<
-        ReadonlyArray<
-          Setter<
-            ReadonlyArray<Setter<number, [number, number]>>,
-            [ReadonlyArray<number>, ReadonlyArray<number>]
-          >
-        >,
+        ReadonlyArray<ReadonlyArray<number>>,
         [ReadonlyArray<ReadonlyArray<number>>, ReadonlyArray<ReadonlyArray<number>>]
       >,
     ) => void
   >()
 
   expectTypeOf(form.getElements(monitor).at(0)!.setInitial).toEqualTypeOf<
-    (
-      setter: Setter<
-        ReadonlyArray<Setter<number, [number, number]>>,
-        [ReadonlyArray<number>, ReadonlyArray<number>]
-      >,
-    ) => void
+    (setter: Setter<ReadonlyArray<number>, [ReadonlyArray<number>, ReadonlyArray<number>]>) => void
   >()
 
   expectTypeOf(
@@ -184,24 +169,6 @@ it("updates list's initial value from an element's setInitial", ({ monitor }) =>
     { first: 1, second: "1" },
     { first: 3, second: "3" },
   ])
-})
-
-it("passes an element in the transform function", ({ monitor }) => {
-  const form = FormList((input: number) => FormUnit(input), {
-    initial: [0, 1, 2],
-  })
-
-  form.setInitial([10, (x) => x + 3])
-  expect(form.getInitial(monitor)).toStrictEqual([10, 4])
-})
-
-it("passes an element in the list transform function", ({ monitor }) => {
-  const form = FormList((input: number) => FormUnit(input), {
-    initial: [0, 1, 2],
-  })
-
-  form.setInitial((elements) => elements.map(() => (x) => x + 1))
-  expect(form.getInitial(monitor)).toStrictEqual([1, 2, 3])
 })
 
 describe("adding a new element to the list's beginning", () => {

--- a/packages/signal-form/tests/form-list/set-input.spec.ts
+++ b/packages/signal-form/tests/form-list/set-input.spec.ts
@@ -1,6 +1,6 @@
 import type { Setter } from "~/tools/setter"
 
-import { FormList, FormUnit } from "../../src"
+import { FormList, FormShape, FormUnit } from "../../src"
 
 it("matches the type definition", ({ monitor }) => {
   const form = FormList((input: number) => FormUnit(input), {
@@ -8,12 +8,7 @@ it("matches the type definition", ({ monitor }) => {
   })
 
   expectTypeOf(form.setInput).toEqualTypeOf<
-    (
-      setter: Setter<
-        ReadonlyArray<Setter<number, [number, number]>>,
-        [ReadonlyArray<number>, ReadonlyArray<number>]
-      >,
-    ) => void
+    (setter: Setter<ReadonlyArray<number>, [ReadonlyArray<number>, ReadonlyArray<number>]>) => void
   >()
 
   expectTypeOf(form.getElements(monitor).at(0)!.setInput).toEqualTypeOf<
@@ -67,24 +62,6 @@ it("passes the list in the transform function", ({ monitor }) => {
   expect(form.getInput(monitor)).toStrictEqual([1, 2, 3])
 })
 
-it("passes an element in the transform function", ({ monitor }) => {
-  const form = FormList((input: number) => FormUnit(input), {
-    initial: [0, 1, 2],
-  })
-
-  form.setInput([10, (x) => x + 3])
-  expect(form.getInput(monitor)).toStrictEqual([10, 4])
-})
-
-it("passes an element in the list transform function", ({ monitor }) => {
-  const form = FormList((input: number) => FormUnit(input), {
-    initial: [0, 1, 2],
-  })
-
-  form.setInput((elements) => elements.map(() => (x) => x + 1))
-  expect(form.getInput(monitor)).toStrictEqual([1, 2, 3])
-})
-
 it("preserves inner list's getInitial after remove + re-add via outer setInput", ({ monitor }) => {
   const outer = FormList(
     (input: ReadonlyArray<number>) => FormList((n: number) => FormUnit(n), { input }),
@@ -103,4 +80,28 @@ it("preserves inner list's getInitial after remove + re-add via outer setInput",
 
   // But the inner list's own getInitial reads from the stale (empty) _initialInputs.
   expect(inner.getInitial(monitor)).toStrictEqual([1, 2, 3])
+})
+
+it("does not allow to set partial initial", ({ monitor }) => {
+  const form = FormList(
+    (input: { first: number; second: string }) =>
+      FormShape({
+        first: FormUnit(input.first),
+        second: FormUnit(input.second),
+      }),
+    {
+      initial: [
+        // @ts-expect-error
+        { first: 1 },
+      ],
+    },
+  )
+
+  // @ts-expect-error
+  form.setInput([{ first: 10 }, { first: 20 }])
+
+  expect(form.getInput(monitor)).toStrictEqual([
+    { first: 10, second: undefined },
+    { first: 20, second: undefined },
+  ])
 })


### PR DESCRIPTION

Revert per-element setter shape from `FormListInputSetter`. Each slot of `FormList.setInput` / `setInitial` / `reset` is now a plain input value again — the same shape as before the previous release. The top-level callback form (a function that returns the full array) is unchanged.

The per-element setter form was unsound for the factory growth path: a partial setter (e.g. `{ first: 2 }` for a `FormShape` element) typechecked at the list level but produced a malformed slot when it reached the factory, which expects a full `GetFormInput<TElement>`. Without a way to type-distinguish "patch existing slot" from "grow new slot", the safer shape is plain inputs.

```ts
const list = FormList(
  (input: { first: number; second: string }) =>
    FormShape({ first: FormUnit(input.first), second: FormUnit(input.second) }),
  { initial: [{ first: 1, second: "1" }] },
)

// Before: per-slot setter was accepted (and could be partial)
list.setInitial([{ first: 2 }])

// After: each slot must be a full input
list.setInitial([{ first: 2, second: "2" }])
```

To update a single element without touching the rest, use the element's own setter:

```ts
list.getElements(monitor).at(0)!.setInitial({ first: 2, second: "2" })
```
